### PR TITLE
fix OUTI/OUTD/OTIR/OTDR

### DIFF
--- a/T80_MCode.vhd
+++ b/T80_MCode.vhd
@@ -2174,8 +2174,6 @@ begin
 				when 2 =>
 					Set_BusB_To <= "0110";
 					Set_Addr_To <= aBC;
-					SetWZ <= "11";
-					IncDec_16(3) <= IR(3);
 				when 3 =>
 					if IR(3) = '0' then
 						IncDec_16 <= "0110";


### PR DESCRIPTION
The OUTI/OUTD/OTIR/OTDR instructions incorrectly update the BC register.

The B register should be updated, but the implementation also updates BC, causing B to be updated twice.

The C128 MiSTer core failed the Vice test for these instructions: https://sourceforge.net/p/vice-emu/code/HEAD/tree/testprogs/c128/z80/outi/

With the change in the pull request, the Vice tests now passed.

I also built the ZX Spectrum MiSTer core with these changes and tested with the Z80Full test program and that still passes the tests for these instuctions.
